### PR TITLE
deprecate usage of underscored protocols, rename Grammar.TerminalSequ…

### DIFF
--- a/sources/ascii.swift
+++ b/sources/ascii.swift
@@ -8,86 +8,86 @@ extension Grammar.Encoding where Terminal == UInt8
 extension Grammar.Encoding.ASCII 
 {
     public
-    enum StartOfHeader:Grammar.TerminalSequence
+    enum StartOfHeader:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x01) }
     }
     
     public
-    enum Backslash:Grammar.TerminalSequence
+    enum Backslash:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x5c) }
     }
     public
-    enum BraceLeft:Grammar.TerminalSequence
+    enum BraceLeft:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x7b) }
     }
     public 
-    enum BraceRight:Grammar.TerminalSequence
+    enum BraceRight:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x7d) }
     }
     public
-    enum BracketLeft:Grammar.TerminalSequence
+    enum BracketLeft:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x5b) }
     }
     public 
-    enum BracketRight:Grammar.TerminalSequence
+    enum BracketRight:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x5d) }
     }
     public
-    enum Colon:Grammar.TerminalSequence
+    enum Colon:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x3a) }
     }
     public
-    enum Comma:Grammar.TerminalSequence
+    enum Comma:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x2c) }
     }
     public
-    enum Dollar:Grammar.TerminalSequence
+    enum Dollar:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x24) }
     }
     public
-    enum Equals:Grammar.TerminalSequence
+    enum Equals:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x3d) }
     }
     public
-    enum Minus:Grammar.TerminalSequence
+    enum Minus:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x2d) }
     }
     public
-    enum Period:Grammar.TerminalSequence
+    enum Period:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x2e) }
     }
     public
-    enum Quote:Grammar.TerminalSequence
+    enum Quote:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x22) }
     }
     public
-    enum Space:Grammar.TerminalSequence
+    enum Space:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x20) }
@@ -97,7 +97,7 @@ extension Grammar.Encoding.ASCII
     enum E 
     {
         public 
-        enum Anycase:Grammar.TerminalClass 
+        enum Anycase:TerminalRule 
         {
             public 
             typealias Construction  = Void
@@ -116,7 +116,7 @@ extension Grammar.Encoding.ASCII
     enum X
     {
         public
-        enum Lowercase:Grammar.TerminalSequence 
+        enum Lowercase:LiteralRule 
         {
             @inlinable public static 
             var literal:CollectionOfOne<UInt8> { .init(0x78) }
@@ -126,7 +126,7 @@ extension Grammar.Encoding.ASCII
     enum U
     {
         public
-        enum Lowercase:Grammar.TerminalSequence 
+        enum Lowercase:LiteralRule 
         {
             @inlinable public static 
             var literal:CollectionOfOne<UInt8> { .init(0x75) }
@@ -134,61 +134,61 @@ extension Grammar.Encoding.ASCII
     }
     
     public
-    enum Zero:Grammar.TerminalSequence
+    enum Zero:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x30) }
     }
     public
-    enum One:Grammar.TerminalSequence
+    enum One:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x31) }
     }
     public
-    enum Two:Grammar.TerminalSequence
+    enum Two:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x32) }
     }
     public
-    enum Three:Grammar.TerminalSequence
+    enum Three:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x33) }
     }
     public
-    enum Four:Grammar.TerminalSequence
+    enum Four:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x34) }
     }
     public
-    enum Five:Grammar.TerminalSequence
+    enum Five:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x35) }
     }
     public
-    enum Six:Grammar.TerminalSequence
+    enum Six:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x36) }
     }
     public
-    enum Seven:Grammar.TerminalSequence
+    enum Seven:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x37) }
     }
     public
-    enum Eight:Grammar.TerminalSequence
+    enum Eight:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x38) }
     }
     public
-    enum Nine:Grammar.TerminalSequence
+    enum Nine:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<UInt8> { .init(0x39) }
@@ -206,7 +206,7 @@ extension Grammar.Digit where Terminal == UInt8
 extension Grammar.Digit.ASCII
 {
     public 
-    enum Decimal:Grammar.DigitRule 
+    enum Decimal:DigitRule 
     {
         @inlinable public static 
         var radix:Construction 
@@ -228,7 +228,7 @@ extension Grammar.Digit.ASCII
     enum Hex 
     {
         public 
-        enum Lowercase:Grammar.DigitRule 
+        enum Lowercase:DigitRule 
         {
             @inlinable public static 
             var radix:Construction 
@@ -247,7 +247,7 @@ extension Grammar.Digit.ASCII
             }
         }
         public 
-        enum Anycase:Grammar.DigitRule 
+        enum Anycase:DigitRule 
         {
             @inlinable public static 
             var radix:Construction 

--- a/sources/grammar.swift
+++ b/sources/grammar.swift
@@ -579,85 +579,17 @@ extension Grammar
 }
 extension Grammar 
 {
+    @available(*, deprecated, renamed: "LiteralRule")
     public 
-    typealias TerminalClass     = _GrammarTerminalClass
+    typealias TerminalSequence  = LiteralRule
+    
+    @available(*, deprecated, renamed: "TerminalRule")
     public 
-    typealias TerminalSequence  = _GrammarTerminalSequence
+    typealias TerminalClass     = TerminalRule
 }
-public
-protocol _GrammarTerminalClass:ParsingRule
-{
-    static 
-    func parse(terminal:Terminal) -> Construction?
-}
-extension Grammar.TerminalClass 
-{
-    @inlinable public static 
-    func parse<Diagnostics>(_ input:inout ParsingInput<Diagnostics>) throws -> Construction
-        where   Diagnostics:ParsingDiagnostics,
-                Diagnostics.Source.Index == Location,
-                Diagnostics.Source.Element == Terminal
-    {
-        guard let terminal:Terminal     = input.next()
-        else 
-        {
-            throw Grammar.Expected<Self>.init()
-        }
-        guard let value:Construction    = Self.parse(terminal: terminal)
-        else 
-        {
-            throw Grammar.Expected<Self>.init()
-        }
-        return value 
-    }
-}
-public
-protocol _GrammarTerminalSequence:ParsingRule
-    where Terminal:Equatable, Construction == Void 
-{
-    associatedtype Literal where Literal:Sequence, Literal.Element == Terminal 
-    static 
-    var literal:Literal
-    {
-        get 
-    }
-}
-extension Grammar.TerminalSequence 
-{
-    @inlinable public static 
-    func parse<Diagnostics>(_ input:inout ParsingInput<Diagnostics>) throws
-        where   Diagnostics:ParsingDiagnostics, 
-                Diagnostics.Source.Index == Location,
-                Diagnostics.Source.Element == Terminal
-    {
-        for expected:Terminal in Self.literal
-        {
-            guard let element:Terminal = input.next()
-            else 
-            {
-                throw Grammar.Expected<Self>.init()
-            }
-            guard element == expected 
-            else 
-            {
-                throw Grammar.Expected<Self>.init()
-            }
-        }
-    }
-}
-public
-protocol _GrammarDigitRule:Grammar.TerminalClass where Construction:BinaryInteger
-{
-    static 
-    var radix:Construction 
-    {
-        get 
-    }
-}
+
 extension Grammar 
 {
-    public 
-    typealias DigitRule = _GrammarDigitRule
     @frozen public
     struct IntegerOverflowError<T>:Error, CustomStringConvertible 
     {

--- a/sources/literalrule.swift
+++ b/sources/literalrule.swift
@@ -1,0 +1,34 @@
+public
+protocol LiteralRule:ParsingRule
+    where Terminal:Equatable, Construction == Void 
+{
+    associatedtype Literal where Literal:Sequence, Literal.Element == Terminal 
+    static 
+    var literal:Literal
+    {
+        get 
+    }
+}
+extension LiteralRule
+{
+    @inlinable public static 
+    func parse<Diagnostics>(_ input:inout ParsingInput<Diagnostics>) throws
+        where   Diagnostics:ParsingDiagnostics, 
+                Diagnostics.Source.Index == Location,
+                Diagnostics.Source.Element == Terminal
+    {
+        for expected:Terminal in Self.literal
+        {
+            guard let element:Terminal = input.next()
+            else 
+            {
+                throw Grammar.Expected<Self>.init()
+            }
+            guard element == expected 
+            else 
+            {
+                throw Grammar.Expected<Self>.init()
+            }
+        }
+    }
+}

--- a/sources/terminalrule.swift
+++ b/sources/terminalrule.swift
@@ -1,0 +1,37 @@
+public
+protocol TerminalRule:ParsingRule
+{
+    static 
+    func parse(terminal:Terminal) -> Construction?
+}
+extension TerminalRule
+{
+    @inlinable public static 
+    func parse<Diagnostics>(_ input:inout ParsingInput<Diagnostics>) throws -> Construction
+        where   Diagnostics:ParsingDiagnostics,
+                Diagnostics.Source.Index == Location,
+                Diagnostics.Source.Element == Terminal
+    {
+        guard let terminal:Terminal     = input.next()
+        else 
+        {
+            throw Grammar.Expected<Self>.init()
+        }
+        guard let value:Construction    = Self.parse(terminal: terminal)
+        else 
+        {
+            throw Grammar.Expected<Self>.init()
+        }
+        return value 
+    }
+}
+
+public
+protocol DigitRule:TerminalRule where Construction:BinaryInteger
+{
+    static 
+    var radix:Construction 
+    {
+        get 
+    }
+}

--- a/sources/unicode.swift
+++ b/sources/unicode.swift
@@ -25,7 +25,7 @@ extension Grammar.Encoding where Terminal == Unicode.Scalar
     enum E 
     {
         public 
-        enum Anycase:Grammar.TerminalClass 
+        enum Anycase:TerminalRule 
         {
             public 
             typealias Construction  = Void
@@ -42,150 +42,150 @@ extension Grammar.Encoding where Terminal == Unicode.Scalar
     }
     
     public
-    enum AngleLeft:Grammar.TerminalSequence
+    enum AngleLeft:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("<") }
     }
     public
-    enum AngleRight:Grammar.TerminalSequence
+    enum AngleRight:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init(">") }
     }
     
     public
-    enum Backslash:Grammar.TerminalSequence
+    enum Backslash:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("\\") }
     }
     public
-    enum BracketLeft:Grammar.TerminalSequence
+    enum BracketLeft:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("[") }
     }
     public
-    enum BracketRight:Grammar.TerminalSequence
+    enum BracketRight:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("]") }
     }
     
     public
-    enum And:Grammar.TerminalSequence
+    enum And:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("&") }
     }
     public
-    enum BraceLeft:Grammar.TerminalSequence
+    enum BraceLeft:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("{") }
     }
     public
-    enum BraceRight:Grammar.TerminalSequence
+    enum BraceRight:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("}") }
     }
     
     public
-    enum Colon:Grammar.TerminalSequence
+    enum Colon:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init(":") }
     }
     public
-    enum Comma:Grammar.TerminalSequence
+    enum Comma:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init(",") }
     }
     public
-    enum Dollar:Grammar.TerminalSequence
+    enum Dollar:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("$") }
     }
     public
-    enum Equals:Grammar.TerminalSequence
+    enum Equals:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("=") }
     }
     public
-    enum Linefeed:Grammar.TerminalSequence
+    enum Linefeed:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("\n") }
     }
     public
-    enum Minus:Grammar.TerminalSequence
+    enum Minus:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("-") }
     }
     
     public
-    enum ParenthesisLeft:Grammar.TerminalSequence
+    enum ParenthesisLeft:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("(") }
     }
     public
-    enum ParenthesisRight:Grammar.TerminalSequence
+    enum ParenthesisRight:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init(")") }
     }
     
     public
-    enum Percent:Grammar.TerminalSequence
+    enum Percent:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("%") }
     }
     public
-    enum Period:Grammar.TerminalSequence
+    enum Period:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init(".") }
     }
     public
-    enum Plus:Grammar.TerminalSequence
+    enum Plus:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("+") }
     }
     public
-    enum Quote:Grammar.TerminalSequence
+    enum Quote:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("\"") }
     }
     public 
-    enum Question:Grammar.TerminalSequence 
+    enum Question:LiteralRule 
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("?") }
     }
     public
-    enum Return:Grammar.TerminalSequence
+    enum Return:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("\r") }
     }
     public
-    enum Slash:Grammar.TerminalSequence
+    enum Slash:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("/") }
     }
     public
-    enum Zero:Grammar.TerminalSequence
+    enum Zero:LiteralRule
     {
         @inlinable public static 
         var literal:CollectionOfOne<Unicode.Scalar> { .init("0") }
@@ -196,7 +196,7 @@ extension Grammar.Encoding where Terminal == Unicode.Scalar
     enum X
     {
         public
-        enum Lowercase:Grammar.TerminalSequence 
+        enum Lowercase:LiteralRule 
         {
             @inlinable public static 
             var literal:CollectionOfOne<Unicode.Scalar> { .init("x") }
@@ -206,14 +206,14 @@ extension Grammar.Encoding where Terminal == Unicode.Scalar
     enum U
     {
         public
-        enum Lowercase:Grammar.TerminalSequence 
+        enum Lowercase:LiteralRule 
         {
             @inlinable public static 
             var literal:CollectionOfOne<Unicode.Scalar> { .init("u") }
         }
     }
     public 
-    enum Whitespace:Grammar.TerminalClass 
+    enum Whitespace:TerminalRule 
     {
         public 
         typealias Construction  = Void
@@ -227,7 +227,7 @@ extension Grammar.Encoding where Terminal == Unicode.Scalar
 extension Grammar.Digit where Terminal == Unicode.Scalar
 {
     public 
-    enum Decimal:Grammar.DigitRule, Grammar.TerminalClass 
+    enum Decimal:DigitRule
     {
         @inlinable public static 
         var radix:Construction 
@@ -257,7 +257,7 @@ extension Grammar.Digit where Terminal == Unicode.Scalar
     enum Hex 
     {
         public 
-        enum Lowercase:Grammar.DigitRule 
+        enum Lowercase:DigitRule 
         {
             @inlinable public static 
             var radix:Construction 
@@ -279,7 +279,7 @@ extension Grammar.Digit where Terminal == Unicode.Scalar
             }
         }
         public 
-        enum Anycase:Grammar.DigitRule 
+        enum Anycase:DigitRule 
         {
             @inlinable public static 
             var radix:Construction 


### PR DESCRIPTION
…ence -> LiteralRule, Grammar.TerminalClass -> TerminalRule