### PR TITLE
deprecate and unify SyncTests, AsyncTests into TestMain, and add the TestBattery protocol for organization

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,18 +12,18 @@ jobs:
         strategy:
             matrix:
                 os: [windows-2022]
-                swift: [5.7.3]
+                swift: [5.9.1]
         steps:
-            -   name: checkout 
+            -   name: checkout
                 uses: actions/checkout@v2
-            
-            -   name: toolchain 
+
+            -   name: toolchain
                 uses: compnerd/gha-setup-swift@v0.0.1
                 with:
                     branch: swift-${{ matrix.swift }}-release
                     tag: ${{ matrix.swift }}-RELEASE
-            -   name: build 
-                run: | 
+            -   name: build
+                run: |
                     swift --version
                     swift build --target Grammar
                     swift build --target TraceableErrors

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
-        "version" : "1.1.0"
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package:Package = .init(
     name: "Swift Grammar",
+    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
     products:
     [
         .library(name: "Grammar", targets: ["Grammar"]),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.8
 import PackageDescription
 
 let package:Package = .init(
@@ -12,7 +12,7 @@ let package:Package = .init(
     dependencies:
     [
         //  This dependency only used for the Testing module’s concurrency support.
-        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.3"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
     ],
     targets:
     [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<strong><em><code>grammar</code></em></strong><br><small><code>0.3.3</code></small>
+<strong><em><code>grammar</code></em></strong><br><small><code>0.3</code></small>
 
 [![ci build status](https://github.com/tayloraswift/swift-grammar/actions/workflows/build.yml/badge.svg)](https://github.com/tayloraswift/swift-grammar/actions/workflows/build.yml)
 [![ci devices build status](https://github.com/tayloraswift/swift-grammar/actions/workflows/build-devices.yml/badge.svg)](https://github.com/tayloraswift/swift-grammar/actions/workflows/build-devices.yml)
@@ -48,7 +48,7 @@ let package = Package(
     dependencies:
     [
         // other dependencies
-        .package(url: "https://github.com/tayloraswift/swift-grammar", from: "0.3.1"),
+        .package(url: "https://github.com/tayloraswift/swift-grammar", from: "0.3.3"),
     ],
     targets:
     [
@@ -65,4 +65,4 @@ let package = Package(
 
 ## toolchain requirement
 
-`swift-grammar` requires Swift 5.7 or newer.
+`swift-grammar` requires Swift 5.8 or newer.

--- a/Sources/Testing/Assertions/Assertion.ExpectedExactFailure.swift
+++ b/Sources/Testing/Assertions/Assertion.ExpectedExactFailure.swift
@@ -6,20 +6,6 @@ extension Assertion
         public
         let expected:Failure
 
-        #if swift(<5.7)
-
-        public
-        let caught:Error?
-
-        public
-        init(caught:Error?, expected:Failure)
-        {
-            self.caught = caught
-            self.expected = expected
-        }
-
-        #else
-
         public
         let caught:(any Error)?
 
@@ -29,65 +15,32 @@ extension Assertion
             self.caught = caught
             self.expected = expected
         }
-
-        #endif
     }
 }
 extension Assertion.ExpectedExactFailure:AssertionFailure
 {
-    #if swift(<5.7)
     public
     var description:String
     {
-        if let caught:Error = self.caught
+        if  let caught:any Error = self.caught
         {
-            return 
-                """
-                Expected error with exact value:
-                ---------------------
-                \(self.expected)
-                ---------------------
-                But caught:
-                ---------------------
-                \(caught)
-                """
+            return """
+            Expected error with exact value:
+            ---------------------
+            \(self.expected)
+            ---------------------
+            But caught:
+            ---------------------
+            \(caught)
+            """
         }
         else
         {
-            return
-                """
-                Expected error with exact value:
-                ---------------------
-                \(self.expected)
-                """
+            return """
+            Expected error with exact value:
+            ---------------------
+            \(self.expected)
+            """
         }
     }
-    #else
-    public
-    var description:String
-    {
-        if let caught:any Error = self.caught
-        {
-            return 
-                """
-                Expected error with exact value:
-                ---------------------
-                \(self.expected)
-                ---------------------
-                But caught:
-                ---------------------
-                \(caught)
-                """
-        }
-        else
-        {
-            return
-                """
-                Expected error with exact value:
-                ---------------------
-                \(self.expected)
-                """
-        }
-    }
-    #endif
 }

--- a/Sources/Testing/Assertions/Assertion.ExpectedFailure.swift
+++ b/Sources/Testing/Assertions/Assertion.ExpectedFailure.swift
@@ -3,19 +3,6 @@ extension Assertion
     public
     struct ExpectedFailure<Expected> where Expected:Error
     {
-        #if swift(<5.7)
-
-        public
-        let caught:Error?
-
-        public
-        init(caught:Error?)
-        {
-            self.caught = caught
-        }
-
-        #else
-
         public
         let caught:(any Error)?
 
@@ -24,53 +11,26 @@ extension Assertion
         {
             self.caught = caught
         }
-
-        #endif
     }
 }
 extension Assertion.ExpectedFailure:AssertionFailure
 {
-    #if swift(<5.7)
-    public
-    var description:String
-    {
-        if let caught:Error = self.caught
-        {
-            return 
-                """
-                Expected error of type \(String.init(reflecting: Expected.self)), but caught:
-                ---------------------
-                \(caught)
-                """
-        }
-        else
-        {
-            return
-                """
-                Expected error of type \(String.init(reflecting: Expected.self))
-                """
-        }
-    }
-    #else
     public
     var description:String
     {
         if let caught:any Error = self.caught
         {
-            return 
-                """
-                Expected error of type \(String.init(reflecting: Expected.self)), but caught:
-                ---------------------
-                \(caught)
-                """
+            return """
+            Expected error of type \(String.init(reflecting: Expected.self)), but caught:
+            ---------------------
+            \(caught)
+            """
         }
         else
         {
-            return
-                """
-                Expected error of type \(String.init(reflecting: Expected.self))
-                """
+            return """
+            Expected error of type \(String.init(reflecting: Expected.self))
+            """
         }
     }
-    #endif
 }

--- a/Sources/Testing/Assertions/Assertion.ExpectedSuccess.swift
+++ b/Sources/Testing/Assertions/Assertion.ExpectedSuccess.swift
@@ -3,19 +3,6 @@ extension Assertion
     public
     struct ExpectedSuccess
     {
-        #if swift(<5.7)
-
-        public
-        let caught:Error
-
-        public
-        init(caught:Error)
-        {
-            self.caught = caught
-        }
-
-        #else
-
         public
         let caught:any Error
 
@@ -24,8 +11,6 @@ extension Assertion
         {
             self.caught = caught
         }
-
-        #endif
     }
 }
 extension Assertion.ExpectedSuccess:AssertionFailure

--- a/Sources/Testing/Deprecated/AsyncTests.swift
+++ b/Sources/Testing/Deprecated/AsyncTests.swift
@@ -1,3 +1,4 @@
+@available(*, deprecated, message: "Use 'TestMain' instead")
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public
 protocol AsyncTests
@@ -5,6 +6,7 @@ protocol AsyncTests
     static
     func run(tests:Tests) async
 }
+@available(*, deprecated)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncTests
 {

--- a/Sources/Testing/Deprecated/SyncTests.swift
+++ b/Sources/Testing/Deprecated/SyncTests.swift
@@ -1,9 +1,11 @@
+@available(*, deprecated, message: "Use 'TestMain' instead")
 public
 protocol SyncTests
 {
     static
     func run(tests:Tests)
 }
+@available(*, deprecated)
 extension SyncTests
 {
     public static

--- a/Sources/Testing/TestBattery.swift
+++ b/Sources/Testing/TestBattery.swift
@@ -1,0 +1,14 @@
+public
+protocol TestBattery
+{
+    static
+    var name:String { get }
+
+    static
+    func run(tests:TestGroup) async throws
+}
+extension TestBattery
+{
+    public static
+    var name:String { "\(Self.self)" }
+}

--- a/Sources/Testing/TestMain.swift
+++ b/Sources/Testing/TestMain.swift
@@ -1,0 +1,44 @@
+#if canImport(Glibc)
+import func Glibc.exit
+#elseif canImport(Darwin)
+import func Darwin.exit
+#endif
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public
+protocol TestMain
+{
+    static
+    var all:[TestBattery.Type] { get }
+}
+extension TestMain
+{
+    public static
+    func main() async throws
+    {
+        let tests:Tests = try .init()
+        for battery:TestBattery.Type in Self.all
+        {
+            if  let group:TestGroup = tests / battery.name
+            {
+                await group.do
+                {
+                    try await battery.run(tests: group)
+                }
+            }
+        }
+        do
+        {
+            try tests.summarize()
+        }
+        catch let error as TestFailures
+        {
+            #if canImport(Glibc) || canImport(Darwin)
+            print(error.description)
+            exit(1)
+            #else
+            throw error
+            #endif
+        }
+    }
+}

--- a/Sources/Testing/TestMain.swift
+++ b/Sources/Testing/TestMain.swift
@@ -11,6 +11,11 @@ protocol TestMain
     static
     var all:[TestBattery.Type] { get }
 }
+extension TestMain where Self:TestBattery
+{
+    public static
+    var all:[TestBattery.Type] { [Self.self] }
+}
 extension TestMain
 {
     public static

--- a/Sources/Testing/Tests/TestFailure.swift
+++ b/Sources/Testing/Tests/TestFailure.swift
@@ -4,19 +4,6 @@ struct TestFailure
     public
     let location:Assertion
 
-    #if swift(<5.7)
-
-    public
-    let failure:AssertionFailure
-    public
-    init(_ failure:AssertionFailure, location:Assertion)
-    {
-        self.location = location
-        self.failure = failure
-    }
-
-    #else
-
     public
     let failure:any AssertionFailure
     public
@@ -25,6 +12,4 @@ struct TestFailure
         self.location = location
         self.failure = failure
     }
-    
-    #endif
 }

--- a/Sources/Testing/Tests/TestGroup.swift
+++ b/Sources/Testing/Tests/TestGroup.swift
@@ -31,11 +31,11 @@ class TestGroup
             ordering: .relaxed)
         self.context.tests.failedAssertions.wrappingIncrement(by: self.failed.count,
             ordering: .relaxed)
-        
+
         self.failed.isEmpty ?
             self.context.tests.passed.wrappingIncrement(ordering: .relaxed) :
             self.context.tests.failed.wrappingIncrement(ordering: .relaxed)
-        
+
         print(self.description)
     }
 }
@@ -124,7 +124,7 @@ extension TestGroup:CustomStringConvertible
 extension TestGroup
 {
     @discardableResult
-    public 
+    public
     func `do`<Success>(
         function:String = #function,
         file:String = #fileID,
@@ -148,7 +148,7 @@ extension TestGroup
             return nil
         }
     }
-    public 
+    public
     func `do`<Failure>(catching expected:Failure.Type,
         function:String = #function,
         file:String = #fileID,
@@ -179,7 +179,7 @@ extension TestGroup
                 file: file,
                 line: line)))
     }
-    public 
+    public
     func `do`<Failure>(catching exact:Failure,
         function:String = #function,
         file:String = #fileID,
@@ -211,12 +211,11 @@ extension TestGroup
                 line: line)))
     }
 }
-#if swift(>=5.5)
-@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+
 extension TestGroup
 {
     @discardableResult
-    public 
+    public
     func `do`<Success>(
         function:String = #function,
         file:String = #fileID,
@@ -240,7 +239,7 @@ extension TestGroup
             return nil
         }
     }
-    public 
+    public
     func `do`<Failure>(catching expected:Failure.Type,
         function:String = #function,
         file:String = #fileID,
@@ -271,7 +270,7 @@ extension TestGroup
                 file: file,
                 line: line)))
     }
-    public 
+    public
     func `do`<Failure>(catching exact:Failure,
         function:String = #function,
         file:String = #fileID,
@@ -303,12 +302,11 @@ extension TestGroup
                 line: line)))
     }
 }
-#endif
 
 extension TestGroup
 {
     @discardableResult
-    public 
+    public
     func expect(true bool:Bool,
         function:String = #function,
         file:String = #fileID,
@@ -331,7 +329,7 @@ extension TestGroup
         }
     }
     @discardableResult
-    public 
+    public
     func expect(false bool:Bool,
         function:String = #function,
         file:String = #fileID,
@@ -355,10 +353,10 @@ extension TestGroup
     }
 
     @discardableResult
-    public 
+    public
     func expect<Expectation>(_ failure:Expectation?,
-        function:String = #function, 
-        file:String = #fileID, 
+        function:String = #function,
+        file:String = #fileID,
         line:Int = #line) -> Bool
         where Expectation:AssertionFailure
     {
@@ -372,7 +370,7 @@ extension TestGroup
                     line: line)))
             return false
         }
-        else 
+        else
         {
             self.passed += 1
             return true
@@ -381,16 +379,16 @@ extension TestGroup
     @discardableResult
     public
     func expect<Wrapped>(value optional:Wrapped?,
-        function:String = #function, 
-        file:String = #fileID, 
+        function:String = #function,
+        file:String = #fileID,
         line:Int = #line) -> Wrapped?
     {
         if  let value:Wrapped = optional
         {
             self.passed += 1
-            return value 
+            return value
         }
-        else 
+        else
         {
             self.failed.append(.init(Assertion.ExpectedValue<Wrapped>.init(),
                 location: .init(
@@ -404,8 +402,8 @@ extension TestGroup
     @discardableResult
     public
     func expect<Wrapped>(nil optional:Wrapped?,
-        function:String = #function, 
-        file:String = #fileID, 
+        function:String = #function,
+        file:String = #fileID,
         line:Int = #line) -> Bool
     {
         if  let value:Wrapped = optional
@@ -419,7 +417,7 @@ extension TestGroup
                     line: line)))
             return false
         }
-        else 
+        else
         {
             self.passed += 1
             return true


### PR DESCRIPTION
hike minimum toolchain requirement to 5.8